### PR TITLE
Remove below_all

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "range-collections"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bytecheck",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ bytecheck = { version = "0.6.5", optional = true }
 num-traits = "0.2.8"
 
 [features]
-default = ["serde"]
+default = ["serde", "rkyv", "rkyv_validated"]
 rkyv_validated = ["rkyv", "bytecheck"]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ smallvec = "1.0"
 serde = { version = "1", optional = true, default-features = false }
 rkyv = { version = "0.7.18", optional = true }
 bytecheck = { version = "0.6.5", optional = true }
+num-traits = "0.2.8"
 
 [features]
 default = ["serde"]
@@ -25,7 +26,6 @@ rkyv_validated = ["rkyv", "bytecheck"]
 quickcheck = "0.8"
 quickcheck_macros = "0.8.0"
 testdrop = "0.1.2"
-num-traits = "0.2.8"
 criterion = "0.3.0"
 rand = "0.7.2"
 serde_cbor = "0.11.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "range-collections"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Rüdiger Klaehn <rklaehn@protonmail.com>"]
 description = "Sets and maps of ranges, backed by smallvec"
 repository = "https://github.com/rklaehn/range-collections"
@@ -16,10 +16,9 @@ smallvec = "1.0"
 serde = { version = "1", optional = true, default-features = false }
 rkyv = { version = "0.7.18", optional = true }
 bytecheck = { version = "0.6.5", optional = true }
-num-traits = "0.2.8"
 
 [features]
-default = ["serde", "rkyv", "rkyv_validated"]
+default = []
 rkyv_validated = ["rkyv", "bytecheck"]
 
 [dev-dependencies]
@@ -31,7 +30,9 @@ rand = "0.7.2"
 serde_cbor = "0.11.1"
 rkyv = { version = "0.7.18", features = ["validation"] }
 hex = "0.4.3"
+num-traits = "0.2.8"
 
 [[bench]]
 name = "range_set"
 harness = false
+

--- a/benches/range_set.rs
+++ b/benches/range_set.rs
@@ -1,7 +1,7 @@
 use core::ops::Range;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rand::prelude::*;
-use range_collections::RangeSet;
+use range_collections::{range_set::AbstractRangeSet, RangeSet};
 
 type Elem = i32;
 

--- a/benches/range_set.rs
+++ b/benches/range_set.rs
@@ -1,7 +1,10 @@
 use core::ops::Range;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rand::prelude::*;
-use range_collections::{range_set::AbstractRangeSet, RangeSet};
+use range_collections::{
+    range_set::{AbstractRangeSet, RangeSet2},
+    RangeSet,
+};
 
 type Elem = i32;
 
@@ -31,19 +34,19 @@ fn create_messages(n: usize, delay: usize) -> Vec<Range<usize>> {
     msgs
 }
 
-fn union_new(a: &RangeSet<Elem>, b: &RangeSet<Elem>) -> RangeSet<Elem> {
+fn union_new(a: &RangeSet2<Elem>, b: &RangeSet2<Elem>) -> RangeSet2<Elem> {
     a | b
 }
 
-fn intersection_new(a: &RangeSet<Elem>, b: &RangeSet<Elem>) -> RangeSet<Elem> {
+fn intersection_new(a: &RangeSet2<Elem>, b: &RangeSet2<Elem>) -> RangeSet2<Elem> {
     a & b
 }
 
-fn intersects_new(a: &RangeSet<Elem>, b: &RangeSet<Elem>) -> bool {
+fn intersects_new(a: &RangeSet2<Elem>, b: &RangeSet2<Elem>) -> bool {
     !a.is_disjoint(b)
 }
 
-fn make_on_off_profile(n: Elem, offset: Elem, stride: Elem) -> RangeSet<Elem> {
+fn make_on_off_profile(n: Elem, offset: Elem, stride: Elem) -> RangeSet2<Elem> {
     let mut res = RangeSet::empty();
     for i in 0..n {
         res ^= RangeSet::from((i * stride + offset)..);
@@ -53,8 +56,8 @@ fn make_on_off_profile(n: Elem, offset: Elem, stride: Elem) -> RangeSet<Elem> {
 
 pub fn interleaved(c: &mut Criterion) {
     let n = 100000;
-    let a: RangeSet<Elem> = make_on_off_profile(n, 0, 2);
-    let b: RangeSet<Elem> = make_on_off_profile(n, 1, 2);
+    let a: RangeSet2<Elem> = make_on_off_profile(n, 0, 2);
+    let b: RangeSet2<Elem> = make_on_off_profile(n, 1, 2);
     c.bench_function("union_interleaved_new", |bencher| {
         bencher.iter(|| union_new(black_box(&a), black_box(&b)))
     });
@@ -68,8 +71,8 @@ pub fn interleaved(c: &mut Criterion) {
 
 pub fn cutoff(c: &mut Criterion) {
     let n = 100000;
-    let a: RangeSet<Elem> = make_on_off_profile(n, 0, 2);
-    let b: RangeSet<Elem> = make_on_off_profile(n, 1, 1000);
+    let a: RangeSet2<Elem> = make_on_off_profile(n, 0, 2);
+    let b: RangeSet2<Elem> = make_on_off_profile(n, 1, 1000);
     c.bench_function("union_cutoff_new", |bencher| {
         bencher.iter(|| union_new(black_box(&a), black_box(&b)))
     });
@@ -86,7 +89,7 @@ pub fn assemble(c: &mut Criterion) {
     let msgs = create_messages(n, 5);
     c.bench_function("assemble", |bencher| {
         bencher.iter(|| {
-            let mut buffer: RangeSet<usize> = RangeSet::from(..0);
+            let mut buffer: RangeSet2<usize> = RangeSet::from(..0);
             for msg in msgs.iter() {
                 buffer |= RangeSet::from(msg.clone());
             }

--- a/benches/range_set.rs
+++ b/benches/range_set.rs
@@ -1,10 +1,7 @@
 use core::ops::Range;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rand::prelude::*;
-use range_collections::{
-    range_set::{AbstractRangeSet, RangeSet2},
-    RangeSet,
-};
+use range_collections::{AbstractRangeSet, RangeSet, RangeSet2};
 
 type Elem = i32;
 

--- a/examples/recv_buffer.rs
+++ b/examples/recv_buffer.rs
@@ -1,5 +1,5 @@
 use rand::prelude::*;
-use range_collections::RangeSet;
+use range_collections::{range_set::RangeSet2, RangeSet};
 use std::ops::{Bound, Range};
 
 fn create_messages(n: usize, delay: usize) -> Vec<Range<usize>> {
@@ -28,8 +28,8 @@ fn create_messages(n: usize, delay: usize) -> Vec<Range<usize>> {
     msgs
 }
 
-fn test(msgs: &Vec<Range<usize>>) -> RangeSet<usize> {
-    let mut buffer: RangeSet<usize> = RangeSet::from(..0);
+fn test(msgs: &Vec<Range<usize>>) -> RangeSet2<usize> {
+    let mut buffer: RangeSet2<usize> = RangeSet::from(..0);
     for msg in msgs.iter().cloned() {
         buffer |= RangeSet::from(msg);
     }
@@ -43,7 +43,7 @@ fn main() {
         test(&msgs);
     }
 
-    let mut buffer: RangeSet<usize> = RangeSet::from(..0);
+    let mut buffer: RangeSet2<usize> = RangeSet::from(..0);
     for (i, msg) in msgs.into_iter().enumerate() {
         buffer |= RangeSet::from(msg);
         if (i % 1000) == 0 {
@@ -57,5 +57,4 @@ fn main() {
         }
     }
     println!("{:?}", buffer);
-    println!("{:?}", buffer.boundaries().capacity());
 }

--- a/src/binary_merge.rs
+++ b/src/binary_merge.rs
@@ -11,11 +11,11 @@ pub(crate) trait MergeStateRead {
     fn a_slice(&self) -> &[Self::A];
     /// The remaining data in b
     fn b_slice(&self) -> &[Self::B];
+    /// current value of a
+    fn ac(&self) -> bool;
+    /// current value of b
+    fn bc(&self) -> bool;
 }
-
-// pub(crate) trait Merger<M> {
-//     fn merge(&self, m: &mut M);
-// }
 
 /// Basically a convenient to use bool to allow aborting a piece of code early using ?
 /// return `None` to abort and `Some(())` to continue

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,4 +26,4 @@ mod obey;
 
 pub mod range_set;
 
-pub use range_set::RangeSet;
+pub use range_set::{RangeSet, RangeSet2};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,4 +26,4 @@ mod obey;
 
 pub mod range_set;
 
-pub use range_set::{RangeSet, RangeSet2};
+pub use range_set::{AbstractRangeSet, RangeSet, RangeSet2};


### PR DESCRIPTION
Range sets now only work for types that have a smallest value. I expect that for the typical use cases this is the case.

This is a breaking change, hence v 0.2.0

Also, serde support is no longer enabled by default, since I personally don't need it at this time.