### PR TITLE
Use refcast to get rid of AbstractRangeSet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597bb81c80a54b6a4381b23faba8d7774b144c94cbd1d6fe3f1329bd776554ab"
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,6 +112,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "cast"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +125,12 @@ checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
 dependencies = [
  "rustc_version",
 ]
+
+[[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -250,6 +277,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +380,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfa919a82ea574332e2de6e74b4c36e74d41982b335080fa59d4ef31be20fdf3"
+dependencies = [
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,9 +430,21 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.108"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+
+[[package]]
+name = "libm"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "log"
@@ -378,11 +472,12 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg 1.0.1",
+ "libm",
 ]
 
 [[package]]
@@ -466,6 +561,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "quick-error 2.0.1",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_xorshift 0.3.0",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,6 +600,18 @@ dependencies = [
  "quote 1.0.10",
  "syn 1.0.82",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quickcheck"
@@ -541,7 +669,7 @@ dependencies = [
  "rand_jitter",
  "rand_os",
  "rand_pcg",
- "rand_xorshift",
+ "rand_xorshift 0.1.1",
  "winapi",
 ]
 
@@ -556,6 +684,17 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -576,6 +715,16 @@ checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -600,6 +749,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
  "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.3",
 ]
 
 [[package]]
@@ -674,8 +832,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "range-collections"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "binary-merge",
  "bytecheck",
@@ -684,9 +851,11 @@ dependencies = [
  "inplace-vec-builder",
  "num-traits",
  "obey",
+ "proptest",
  "quickcheck",
  "quickcheck_macros",
  "rand 0.7.3",
+ "ref-cast",
  "rkyv",
  "serde",
  "serde_cbor",
@@ -726,6 +895,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 dependencies = [
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9af2cf09ef80e610097515e80095b7f76660a92743c4185aff5406cd5ce3dd5"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c501201393982e275433bc55de7d6ae6f00e7699cd5572c5b57581cd69c881b"
+dependencies = [
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.82",
 ]
 
 [[package]]
@@ -792,6 +990,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.36.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -894,6 +1118,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "testdrop"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,6 +1156,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -941,6 +1184,15 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"
@@ -1059,3 +1311,84 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "range-collections"
-version = "0.2.4"
+version = "0.3.0"
 authors = ["Rüdiger Klaehn <rklaehn@protonmail.com>"]
 description = "Sets and maps of ranges, backed by smallvec"
 repository = "https://github.com/rklaehn/range-collections"
@@ -18,6 +18,7 @@ binary-merge = "0.1.1"
 serde = { version = "1", optional = true, default-features = false }
 rkyv = { version = "0.7.18", optional = true }
 bytecheck = { version = "0.6.5", optional = true }
+ref-cast = "1.0.15"
 
 [features]
 default = []
@@ -34,6 +35,7 @@ rkyv = { version = "0.7.18", features = ["validation"] }
 hex = "0.4.3"
 num-traits = "0.2.8"
 obey = "0.1.0"
+proptest = "1.1.0"
 
 [[bench]]
 name = "range_set"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ ref-cast = "1.0.15"
 [features]
 default = []
 rkyv_validated = ["rkyv", "bytecheck"]
+new_unchecked = []
 
 [dev-dependencies]
 quickcheck = "0.8"

--- a/benches/range_set.rs
+++ b/benches/range_set.rs
@@ -1,7 +1,7 @@
 use core::ops::Range;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rand::prelude::*;
-use range_collections::{AbstractRangeSet, RangeSet, RangeSet2};
+use range_collections::{RangeSet, RangeSet2};
 
 type Elem = i32;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,4 +13,4 @@ mod iterators;
 
 pub mod range_set;
 
-pub use range_set::{AbstractRangeSet, RangeSet, RangeSet2};
+pub use range_set::{RangeSet, RangeSet2, RangeSetRef};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! collections (set and maps) with ranges as keys, backed by SmallVec<T>
+//! collections (set and maps) with ranges as keys, backed by `SmallVec<T>`
 #[cfg(test)]
 extern crate quickcheck;
 

--- a/src/range_set.rs
+++ b/src/range_set.rs
@@ -11,7 +11,11 @@ use core::ops::{
     BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Bound, Bound::*, Not, Range,
     RangeFrom, RangeTo, Sub, SubAssign,
 };
+use ref_cast::RefCast;
 use smallvec::{Array, SmallVec};
+use std::borrow::Borrow;
+use std::num::*;
+use std::ops::Deref;
 #[cfg(feature = "serde")]
 use {
     core::{fmt, marker::PhantomData},
@@ -88,6 +92,26 @@ use {
 /// Testing is done by some simple smoke tests as well as quickcheck tests of the algebraic properties of the boolean operations.
 pub struct RangeSet<A: Array>(SmallVec<A>);
 
+impl<T, A: Array<Item = T>> Deref for RangeSet<A> {
+    type Target = RangeSetRef<T>;
+
+    fn deref(&self) -> &Self::Target {
+        RangeSetRef::new_unchecked(&self.0)
+    }
+}
+
+impl<T, A: Array<Item = T>> AsRef<RangeSetRef<T>> for RangeSet<A> {
+    fn as_ref(&self) -> &RangeSetRef<T> {
+        RangeSetRef::new_unchecked(&self.0)
+    }
+}
+
+impl<T, A: Array<Item = T>> Borrow<RangeSetRef<T>> for RangeSet<A> {
+    fn borrow(&self) -> &RangeSetRef<T> {
+        RangeSetRef::new_unchecked(&self.0)
+    }
+}
+
 impl<A: Array> Clone for RangeSet<A>
 where
     A::Item: Clone,
@@ -97,12 +121,12 @@ where
     }
 }
 
-impl<A: Array, R: AbstractRangeSet<A::Item>> PartialEq<R> for RangeSet<A>
+impl<A: Array, R: AsRef<RangeSetRef<A::Item>>> PartialEq<R> for RangeSet<A>
 where
     A::Item: RangeSetEntry,
 {
     fn eq(&self, that: &R) -> bool {
-        AbstractRangeSet::<A::Item>::boundaries(self) == that.boundaries()
+        self.boundaries() == that.as_ref().boundaries()
     }
 }
 
@@ -152,24 +176,56 @@ impl<'a, T> Iterator for Iter<'a, T> {
     }
 }
 
-/// Anything that provides sorted boundaries
-///
-/// This is just implemented for ArchivedRangeSet and RangeSet.
-/// It probably does not make sense to implement it yourself.
-pub trait AbstractRangeSet<T> {
-    /// the boundaries as a reference - must be strictly sorted
-    fn boundaries(&self) -> &[T];
+/// A reference to a range set
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, RefCast)]
+#[repr(transparent)]
+pub struct RangeSetRef<T>([T]);
 
-    /// convert to a normal range set
-    fn to_range_set<A: Array<Item = T>>(&self) -> RangeSet<A>
+impl<T> RangeSetRef<T> {
+    /// Create a new range set reference
+    pub fn new(boundaries: &[T]) -> Option<&Self>
     where
-        T: Clone,
+        T: Ord,
     {
-        RangeSet::new(self.boundaries().into())
+        if is_strictly_sorted(&boundaries) {
+            Some(Self::new_unchecked(boundaries))
+        } else {
+            None
+        }
+    }
+
+    /// Split this range set into two parts `left`, `right` at position `at`,
+    /// so that `left` is identical to `self` for all `x < at`
+    /// and `right` is identical to `self` for all `x >= at`.
+    ///
+    /// More precisely:
+    ///   contains(left, x) == contains(ranges, x) for x < at
+    ///   contains(right, x) == contains(ranges, x) for x >= at
+    ///
+    /// This is not the same as limiting the ranges to the left or right of
+    /// `at`, but it is much faster. It requires just a binary search and no
+    /// allocations.
+    pub fn split(&self, at: T) -> (&Self, &Self)
+    where
+        T: Ord,
+    {
+        let (left, right) = split(&self.0, at);
+        (Self::new_unchecked(left), Self::new_unchecked(right))
+    }
+
+    /// Create a new range set reference without checking that the boundaries are
+    /// strictly sorted.
+    fn new_unchecked(boundaries: &[T]) -> &Self {
+        Self::ref_cast(boundaries)
+    }
+
+    /// The boundaries of the range set, guaranteed to be strictly sorted
+    pub fn boundaries(&self) -> &[T] {
+        &self.0
     }
 
     /// true if the value is contained in the range set
-    fn contains(&self, value: &T) -> bool
+    pub fn contains(&self, value: &T) -> bool
     where
         T: Ord,
     {
@@ -180,12 +236,12 @@ pub trait AbstractRangeSet<T> {
     }
 
     /// true if the range set is empty
-    fn is_empty(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.boundaries().is_empty()
     }
 
     /// true if the range set contains all values
-    fn is_all(&self) -> bool
+    pub fn is_all(&self) -> bool
     where
         T: RangeSetEntry,
     {
@@ -193,9 +249,9 @@ pub trait AbstractRangeSet<T> {
     }
 
     /// true if this range set is disjoint from another range set
-    fn is_disjoint(&self, that: &impl AbstractRangeSet<T>) -> bool
+    pub fn is_disjoint(&self, that: &RangeSetRef<T>) -> bool
     where
-        T: RangeSetEntry,
+        T: Ord,
     {
         !RangeSetBoolOpMergeState::merge(self.boundaries(), that.boundaries(), IntersectionOp::<0>)
     }
@@ -203,7 +259,7 @@ pub trait AbstractRangeSet<T> {
     /// true if this range set is a superset of another range set
     ///
     /// A range set is considered to be a superset of itself
-    fn is_subset(&self, that: impl AbstractRangeSet<T>) -> bool
+    pub fn is_subset(&self, that: &RangeSetRef<T>) -> bool
     where
         T: Ord,
     {
@@ -213,7 +269,7 @@ pub trait AbstractRangeSet<T> {
     /// true if this range set is a subset of another range set
     ///
     /// A range set is considered to be a subset of itself
-    fn is_superset(&self, that: impl AbstractRangeSet<T>) -> bool
+    pub fn is_superset(&self, that: &RangeSetRef<T>) -> bool
     where
         T: Ord,
     {
@@ -221,11 +277,12 @@ pub trait AbstractRangeSet<T> {
     }
 
     /// iterate over all ranges in this range set
-    fn iter(&self) -> Iter<T> {
+    pub fn iter(&self) -> Iter<T> {
         Iter(self.boundaries())
     }
+
     /// intersection
-    fn intersection<A>(&self, that: &impl AbstractRangeSet<T>) -> RangeSet<A>
+    pub fn intersection<A>(&self, that: &RangeSetRef<T>) -> RangeSet<A>
     where
         A: Array<Item = T>,
         T: Ord + Clone,
@@ -236,8 +293,9 @@ pub trait AbstractRangeSet<T> {
             IntersectionOp::<{ usize::MAX }>,
         ))
     }
+
     /// union
-    fn union<A>(&self, that: &impl AbstractRangeSet<T>) -> RangeSet<A>
+    pub fn union<A>(&self, that: &RangeSetRef<T>) -> RangeSet<A>
     where
         A: Array<Item = T>,
         T: Ord + Clone,
@@ -248,8 +306,9 @@ pub trait AbstractRangeSet<T> {
             UnionOp,
         ))
     }
+
     /// difference
-    fn difference<A>(&self, that: &impl AbstractRangeSet<T>) -> RangeSet<A>
+    pub fn difference<A>(&self, that: &RangeSetRef<T>) -> RangeSet<A>
     where
         A: Array<Item = T>,
         T: Ord + Clone,
@@ -260,8 +319,9 @@ pub trait AbstractRangeSet<T> {
             DiffOp::<{ usize::MAX }>,
         ))
     }
+
     /// symmetric difference (xor)
-    fn symmetric_difference<A>(&self, that: &impl AbstractRangeSet<T>) -> RangeSet<A>
+    pub fn symmetric_difference<A>(&self, that: &RangeSetRef<T>) -> RangeSet<A>
     where
         A: Array<Item = T>,
         T: Ord + Clone,
@@ -274,35 +334,26 @@ pub trait AbstractRangeSet<T> {
     }
 }
 
-impl<A: Array> AbstractRangeSet<A::Item> for RangeSet<A>
-where
-    A::Item: RangeSetEntry,
-{
-    fn boundaries(&self) -> &[A::Item] {
-        self.0.as_ref()
-    }
-}
+#[cfg(feature = "rkyv")]
+impl<T> Deref for ArchivedRangeSet<T> {
+    type Target = RangeSetRef<T>;
 
-impl<A: Array> AbstractRangeSet<A::Item> for &RangeSet<A>
-where
-    A::Item: RangeSetEntry,
-{
-    fn boundaries(&self) -> &[A::Item] {
-        self.0.as_ref()
+    fn deref(&self) -> &Self::Target {
+        RangeSetRef::new_unchecked(&self.0)
     }
 }
 
 #[cfg(feature = "rkyv")]
-impl<T> AbstractRangeSet<T> for ArchivedRangeSet<T> {
-    fn boundaries(&self) -> &[T] {
-        self.0.as_ref()
+impl<T> AsRef<RangeSetRef<T>> for ArchivedRangeSet<T> {
+    fn as_ref(&self) -> &RangeSetRef<T> {
+        RangeSetRef::new_unchecked(&self.0)
     }
 }
 
 #[cfg(feature = "rkyv")]
-impl<T> AbstractRangeSet<T> for &ArchivedRangeSet<T> {
-    fn boundaries(&self) -> &[T] {
-        self.0.as_ref()
+impl<T> Borrow<RangeSetRef<T>> for ArchivedRangeSet<T> {
+    fn borrow(&self) -> &RangeSetRef<T> {
+        RangeSetRef::new_unchecked(&self.0)
     }
 }
 
@@ -337,8 +388,44 @@ macro_rules! entry_instance {
     }
 }
 
+macro_rules! non_zero_u_entry_instance {
+    ($t:tt) => {
+        impl RangeSetEntry for $t {
+            fn min_value() -> Self {
+                $t::new(1).unwrap()
+            }
+
+            fn is_min_value(&self) -> bool {
+                *self == $t::new(1).unwrap()
+            }
+        }
+    };
+    ($t:tt, $($rest:tt),+) => {
+        non_zero_u_entry_instance!($t);
+        non_zero_u_entry_instance!($( $rest ),*);
+    }
+}
+
 entry_instance!(u8, u16, u32, u64, u128, usize);
 entry_instance!(i8, i16, i32, i64, i128, isize);
+non_zero_u_entry_instance!(
+    NonZeroU8,
+    NonZeroU16,
+    NonZeroU32,
+    NonZeroU64,
+    NonZeroU128,
+    NonZeroUsize
+);
+
+impl<T: Ord> RangeSetEntry for Option<T> {
+    fn min_value() -> Self {
+        None
+    }
+
+    fn is_min_value(&self) -> bool {
+        self.is_none()
+    }
+}
 
 impl RangeSetEntry for String {
     fn min_value() -> Self {
@@ -423,7 +510,7 @@ impl<T: RangeSetEntry, A: Array<Item = T>> RangeSet<A> {
 
 impl<T: RangeSetEntry + Clone, A: Array<Item = T>> RangeSet<A> {
     /// intersection in place
-    pub fn intersection_with(&mut self, that: &impl AbstractRangeSet<T>) {
+    pub fn intersection_with(&mut self, that: &RangeSetRef<T>) {
         InPlaceMergeStateRef::merge(
             &mut self.0,
             &that.boundaries(),
@@ -431,15 +518,15 @@ impl<T: RangeSetEntry + Clone, A: Array<Item = T>> RangeSet<A> {
         );
     }
     /// union in place
-    pub fn union_with(&mut self, that: &impl AbstractRangeSet<T>) {
+    pub fn union_with(&mut self, that: &RangeSetRef<T>) {
         InPlaceMergeStateRef::merge(&mut self.0, &that.boundaries(), UnionOp);
     }
     /// difference in place
-    pub fn difference_with(&mut self, that: &impl AbstractRangeSet<T>) {
+    pub fn difference_with(&mut self, that: &RangeSetRef<T>) {
         InPlaceMergeStateRef::merge(&mut self.0, &that.boundaries(), DiffOp::<{ usize::MAX }>);
     }
     /// symmetric difference in place (xor)
-    pub fn symmetric_difference_with(&mut self, that: &impl AbstractRangeSet<T>) {
+    pub fn symmetric_difference_with(&mut self, that: &RangeSetRef<T>) {
         InPlaceMergeStateRef::merge(&mut self.0, &that.boundaries(), XorOp);
     }
 }
@@ -575,11 +662,6 @@ impl<T: RangeSetEntry + Clone, A: Array<Item = T>> Not for &RangeSet<A> {
     fn not(self) -> Self::Output {
         self ^ &RangeSet::all()
     }
-}
-
-#[inline]
-fn is_odd(x: usize) -> bool {
-    (x & 1) != 0
 }
 
 struct RangeSetBoolOpMergeState<'a, T> {
@@ -899,6 +981,183 @@ impl<'a, T: Ord, M: MergeStateMut<A = T, B = T>> MergeOperation<M> for XorOp {
     }
     fn cmp(&self, a: &T, b: &T) -> Ordering {
         a.cmp(b)
+    }
+}
+
+#[inline]
+fn is_odd(x: usize) -> bool {
+    (x & 1) != 0
+}
+
+#[inline]
+fn is_even(x: usize) -> bool {
+    (x & 1) == 0
+}
+
+fn is_strictly_sorted<T: Ord>(ranges: &[T]) -> bool {
+    for i in 0..ranges.len().saturating_sub(1) {
+        if ranges[i] >= ranges[i + 1] {
+            return false;
+        }
+    }
+    true
+}
+
+/// Split a strictly ordered sequence of boundaries `ranges` into two parts
+/// `left`, `right` at position `at`, so that
+///   contains(left, x) == contains(ranges, x) for x < at
+///   contains(right, x) == contains(ranges, x) for x >= at
+#[inline]
+fn split<'a, T: Ord>(ranges: &'a [T], at: T) -> (&'a [T], &'a [T]) {
+    let l = ranges.len();
+    let res = ranges.binary_search(&at);
+    match res {
+        Ok(i) if is_even(i) => {
+            // left will be an even size, so we can just cut it off
+            (&ranges[..i], &ranges[i..])
+        }
+        Err(i) if is_even(i) => {
+            // right will be an even size, so we can just cut it off
+            (&ranges[..i], &ranges[i..])
+        }
+        Ok(i) => {
+            // left will be an odd size, so we need to add one if possible
+            //
+            // since i is an odd value, it indicates going to false at the
+            // split point, and we don't need to have it in right.
+            let sp = i.saturating_add(1).min(l);
+            (&ranges[..sp], &ranges[sp..])
+        }
+        Err(i) => {
+            // left will be an odd size, so we add one if possible
+            //
+            // i is an odd value, so right is true at the split point, and
+            // we need to add one value before the split point to right.
+            // hence the saturating_sub(1).
+            (
+                &ranges[..i.saturating_add(1).min(l)],
+                &ranges[i.saturating_sub(1)..],
+            )
+        }
+    }
+}
+
+/// For a strictly ordered sequence of boundaries `ranges`, checks if the
+/// value at `at` is true.
+#[allow(dead_code)]
+fn contains<T: Ord>(boundaries: &[T], value: &T) -> bool {
+    match boundaries.binary_search(value) {
+        Ok(index) => !is_odd(index),
+        Err(index) => is_odd(index),
+    }
+}
+
+/// Check if a sequence of boundaries `ranges` intersects with a range
+#[allow(dead_code)]
+fn intersects<T: Ord>(boundaries: &[T], range: Range<T>) -> bool {
+    let (_, remaining) = split(boundaries, range.start);
+    let (remaining, _) = split(remaining, range.end);
+    // remaining is not the intersection but can be larger.
+    // But if remaining is empty, then we know that the intersection is empty.
+    !remaining.is_empty()
+}
+
+#[cfg(test)]
+mod util_tests {
+    use std::{collections::BTreeSet, ops::Range};
+
+    use super::*;
+    use proptest::prelude::*;
+
+    fn test_points(boundaries: impl IntoIterator<Item = u64>) -> BTreeSet<u64> {
+        let mut res = BTreeSet::new();
+        for x in boundaries {
+            res.insert(x.saturating_sub(1));
+            res.insert(x);
+            res.insert(x.saturating_add(1));
+        }
+        res
+    }
+
+    fn test_boundaries() -> impl Strategy<Value = (Vec<u64>, u64)> {
+        proptest::collection::vec(any::<u64>(), 0..100).prop_flat_map(|mut v| {
+            v.sort();
+            v.dedup();
+            // split point should occasionally be outside of the range
+            let max_split = v
+                .iter()
+                .max()
+                .cloned()
+                .unwrap_or_default()
+                .saturating_add(2);
+            (Just(v), 0..max_split)
+        })
+    }
+
+    proptest! {
+        #[test]
+        fn test_split((boundaries, at) in test_boundaries()) {
+            let (left, right) = split(&boundaries, at);
+            for x in test_points(boundaries.clone()) {
+                // test that split does what it promises
+                if x < at {
+                    prop_assert_eq!(contains(left, &x), contains(&boundaries, &x), "left must be like boundaries for x < at");
+                } else {
+                    prop_assert_eq!(contains(right, &x), contains(&boundaries, &x), "right must be like boundaries for x >= at");
+                }
+                // test that split is not just returning the input, but minimal parts
+                let nr = right.iter().filter(|x| x < &&at).count();
+                prop_assert!(nr <= 1, "there must be at most one boundary before the split point");
+                let nl = left.iter().filter(|x| x >= &&at).count();
+                prop_assert!(nl <= 1, "there must be at most one boundary after the split point");
+            }
+        }
+    }
+
+    #[test]
+    fn test_split_0() {
+        let cases: Vec<(&[u64], u64, (&[u64], &[u64]))> = vec![
+            (&[0, 2], 0, (&[], &[0, 2])),
+            (&[0, 2], 2, (&[0, 2], &[])),
+            (&[0, 2, 4], 2, (&[0, 2], &[4])),
+            (&[0, 2, 4], 4, (&[0, 2], &[4])),
+            (&[0, 2, 4, 8], 2, (&[0, 2], &[4, 8])),
+            (&[0, 2, 4, 8], 4, (&[0, 2], &[4, 8])),
+            (&[0, 2, 4, 8], 3, (&[0, 2], &[4, 8])),
+            (&[0, 2, 4, 8], 6, (&[0, 2, 4, 8], &[4, 8])),
+        ];
+        for (ranges, pos, (left, right)) in cases {
+            assert_eq!(split(&ranges, pos), (left, right));
+        }
+    }
+
+    #[test]
+    fn test_intersects_0() {
+        let cases: Vec<(&[u64], Range<u64>, bool)> = vec![
+            (&[0, 2], 0..2, true),
+            (&[0, 2], 2..4, false),
+            (&[0, 2, 4, 8], 0..2, true),
+            (&[0, 2, 4, 8], 2..4, false),
+            (&[0, 2, 4, 8], 4..8, true),
+            (&[0, 2, 4, 8], 8..12, false),
+        ];
+        for (ranges, range, expected) in cases {
+            assert_eq!(intersects(&ranges, range), expected);
+        }
+    }
+
+    #[test]
+    fn contains_0() {
+        let cases: Vec<(&[u64], u64, bool)> = vec![
+            (&[0, 2], 0, true),
+            (&[0, 2], 1, true),
+            (&[0, 2], 2, false),
+            (&[0, 2, 4, 8], 3, false),
+            (&[0, 2, 4, 8], 4, true),
+        ];
+        for (ranges, pos, expected) in cases {
+            assert_eq!(contains(ranges, &pos), expected);
+        }
     }
 }
 

--- a/src/range_set.rs
+++ b/src/range_set.rs
@@ -261,6 +261,17 @@ impl<T> RangeSetRef<T> {
         self.boundaries().len() == 1 && self.boundaries()[0].is_min_value()
     }
 
+    /// true if this range set intersects from another range set
+    ///
+    /// This is just the opposite of `is_disjoint`, but is provided for
+    /// better discoverability.
+    pub fn intersects(&self, that: &RangeSetRef<T>) -> bool
+    where
+        T: Ord,
+    {
+        !self.is_disjoint(that)
+    }
+
     /// true if this range set is disjoint from another range set
     pub fn is_disjoint(&self, that: &RangeSetRef<T>) -> bool
     where


### PR DESCRIPTION
It's always just a newtype for a sorted slice. No need for traits.